### PR TITLE
Add toolchain file for rustup

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Specify toolchain to use in rustup.
+# Without this file, compilation would fail if no prior toolchain
+# is installed (such as on a fresh ArchLinux+rustup installation)
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
This way, the package can be built without any prior
commands on systems that do not ship a default toolchain
(such as on ArchLinux).

In other words, without this change, the package will fail
to build on a clean system on rustup+ArchLinux.