### PR TITLE
Updated debian script

### DIFF
--- a/pkg/debian-install.sh
+++ b/pkg/debian-install.sh
@@ -6,7 +6,7 @@ main(){
     which curl >/dev/null && echo "Curl installed, moving on..." || sudo apt install curl
 
     echo "Getting latest version..."
-    version=$(curl --silent "https://api.github.com/repos/robiot/rustcat/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
+    version=$(curl --silent "https://api.github.com/repos/robiot/rustcat/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     name="rcat-${version}-linux-x86_64.deb"
 
     echo "Found $name"

--- a/pkg/debian-install.sh
+++ b/pkg/debian-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Tested on kali linux 2021.2 live iso
+# Tested on kali linux 2024.1 VMware image
 main(){
     echo "Welcome to the Rustcat Debian installer"
     which curl >/dev/null && echo "Curl installed, moving on..." || sudo apt install curl


### PR DESCRIPTION
Releases previous to version 3.0.0 used `#.#.#` in the file name to indicate the version. Version 3.0.0 uses `v#.#.#`, i.e. it includes the 'v' before the version number. The bash command in the `debian-install.sh` script to set the version variable removed the 'v', so I updated it to keep the 'v'.

I then tested it on the current Kali Linux pre-built VMware image. 

closes #64 